### PR TITLE
make Pdf Viewer behave like Android 5.0 "Document Task"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 .gradle
 local.properties
 build/
+
+.idea/
+*.iml

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,13 +1,49 @@
 apply plugin: 'com.android.application'
 
+/* gets the version name from the latest Git tag */
+def getGitVersionName = { ->
+    def stdout = new ByteArrayOutputStream()
+    exec {
+        commandLine 'git', 'describe', '--tags', '--always'
+        standardOutput = stdout
+    }
+    return stdout.toString().trim()
+}
+
 android {
     compileSdkVersion 26
     buildToolsVersion "26.0.1"
+
+    defaultConfig {
+        applicationId "co.copperhead.pdfviewer"
+    }
 
     buildTypes {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+        }
+        debug {
+            applicationIdSuffix ".debug"
+            versionNameSuffix "-" + getGitVersionName()
+        }
+    }
+
+    /* set the debug versionCode based on how many commits in the repo */
+    applicationVariants.all { variant ->
+        if (variant.buildType.isDebuggable()) {
+            // default to a timestamp, in case anything fails later
+            variant.mergedFlavor.versionCode = new Date().getTime() / 1000
+            try {
+                def stdout = new ByteArrayOutputStream()
+                exec {
+                    commandLine 'git', 'rev-list', '--first-parent', '--count', 'HEAD'
+                    standardOutput = stdout
+                }
+                variant.mergedFlavor.versionCode = Integer.parseInt(stdout.toString().trim())
+            }
+            catch (ignored) {
+            }
         }
     }
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -10,6 +10,7 @@
             android:label="@string/app_name"
             android:theme="@style/AppTheme">
         <activity android:name="co.copperhead.pdfviewer.PdfViewer"
+                  android:documentLaunchMode="intoExisting"
                 android:label="@string/app_name">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/app/src/main/java/co/copperhead/pdfviewer/PdfViewer.java
+++ b/app/src/main/java/co/copperhead/pdfviewer/PdfViewer.java
@@ -12,6 +12,7 @@ import android.graphics.Color;
 import android.graphics.drawable.Drawable;
 import android.net.Uri;
 import android.os.AsyncTask;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
 import android.provider.OpenableColumns;
@@ -20,6 +21,7 @@ import android.view.Gravity;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
+import android.view.WindowManager;
 import android.webkit.CookieManager;
 import android.webkit.JavascriptInterface;
 import android.webkit.WebResourceRequest;
@@ -292,6 +294,8 @@ public class PdfViewer extends Activity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
+        getWindow().addFlags(WindowManager.LayoutParams.FLAG_SECURE);
+
         setContentView(R.layout.webview);
         ActionBar actionBar = getActionBar();
         if (actionBar != null) {
@@ -411,7 +415,11 @@ public class PdfViewer extends Activity {
                 public void run() {
                     mWebView.loadUrl("about:blank");
                     mDocumentProperties = null;
-                    finish();
+                    if (Build.VERSION.SDK_INT < 21) {
+                        finish();
+                    } else {
+                        finishAndRemoveTask();
+                    }
                 }
             });
         }

--- a/app/src/main/java/co/copperhead/pdfviewer/PdfViewer.java
+++ b/app/src/main/java/co/copperhead/pdfviewer/PdfViewer.java
@@ -5,6 +5,7 @@ import android.app.ActionBar;
 import android.app.Activity;
 import android.app.ActivityManager;
 import android.content.ContentResolver;
+import android.content.Context;
 import android.content.Intent;
 import android.content.res.ColorStateList;
 import android.database.ContentObserver;
@@ -24,7 +25,9 @@ import android.view.Gravity;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
+import android.view.View;
 import android.view.WindowManager;
+import android.view.inputmethod.InputMethodManager;
 import android.webkit.CookieManager;
 import android.webkit.JavascriptInterface;
 import android.webkit.WebResourceRequest;
@@ -305,6 +308,14 @@ public class PdfViewer extends Activity {
             actionBar.setDisplayHomeAsUpEnabled(true);
             actionBar.setHomeActionContentDescription(R.string.action_close);
         }
+
+        // some apps launch the PDF document, but leave the keyboard open, so hide it
+        View view = this.getCurrentFocus();
+        if (view == null) {
+            view = findViewById(android.R.id.content).getRootView();
+        }
+        InputMethodManager imm = (InputMethodManager)getSystemService(Context.INPUT_METHOD_SERVICE);
+        imm.hideSoftInputFromWindow(view.getWindowToken(), 0);
 
         mWebView = (WebView) findViewById(R.id.webview);
         WebSettings settings = mWebView.getSettings();

--- a/app/src/main/res/menu/pdf_viewer.xml
+++ b/app/src/main/res/menu/pdf_viewer.xml
@@ -19,10 +19,16 @@
         android:showAsAction="ifRoom" />
 
     <item
-        android:id="@+id/action_open"
-        android:icon="@drawable/ic_insert_drive_file_white_24dp"
-        android:title="@string/action_open"
-        android:showAsAction="ifRoom" />
+            android:id="@+id/action_open"
+            android:icon="@drawable/ic_insert_drive_file_white_24dp"
+            android:title="@string/action_open"
+            android:showAsAction="ifRoom" />
+
+    <item
+            android:id="@+id/action_close"
+            android:icon="@android:drawable/ic_menu_close_clear_cancel"
+            android:title="@string/action_close"
+            android:showAsAction="ifRoom" />
 
     <item
         android:id="@+id/action_zoom_out"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -5,6 +5,7 @@
     <string name="action_previous">Next page</string>
     <string name="action_next">Previous page</string>
     <string name="action_open">Open document</string>
+    <string name="action_close">Close document</string>
     <string name="action_zoom_out">Zoom out</string>
     <string name="action_zoom_in">Zoom in</string>
     <string name="action_jump_to_page">Jump to page</string>


### PR DESCRIPTION
Android 5.0 started making document viewer apps behave like multiple windows.  This makes Pdf Viewer act like that.  It also makes Pdf Viewer listen to changes in the `ContentProvider` that it received files from other apps.  So if OpenKeychain locks, then Pdf Viewer will stop showing the PGP-encrypted document.