### PR TITLE
Portray empty metadata as hyphen for consistency

### DIFF
--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string-array name="document_properties">
+        <item>File name</item>
+        <item>File size</item>
+        <item>Title</item>
+        <item>Author</item>
+        <item>Subject</item>
+        <item>Keywords</item>
+        <item>Creation date</item>
+        <item>Modify date</item>
+        <item>Producer</item>
+        <item>Creator</item>
+        <item>PDF version</item>
+        <item>Pages</item>
+    </string-array>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -10,18 +10,6 @@
     <string name="action_jump_to_page">Jump to page</string>
     <string name="action_view_document_properties">Document properties</string>
 
-    <string name="document_properties_file_name">File name</string>
-    <string name="document_properties_file_size">File size</string>
-    <string name="document_properties_title">Title</string>
-    <string name="document_properties_author">Author</string>
-    <string name="document_properties_subject">Subject</string>
-    <string name="document_properties_keywords">Keywords</string>
-    <string name="document_properties_creation_date">Creation date</string>
-    <string name="document_properties_modify_date">Modify date</string>
     <string name="document_properties_invalid_date">Invalid date</string>
-    <string name="document_properties_producer">Producer</string>
-    <string name="document_properties_creator">Creator</string>
-    <string name="document_properties_pdf_version">PDF version</string>
-    <string name="document_properties_pages">Pages</string>
     <string name="document_properties_retrieval_failed">Failed to obtain document metadata</string>
 </resources>


### PR DESCRIPTION
This is done the same on the pdf.js web viewer.

@thestinger 
I'll upstream all minor patches now so that i can cleanse my fork,
as those won't require deeper analysis.