### PR TITLE
Fix number picker ignoring user input

### DIFF
--- a/app/src/main/java/co/copperhead/pdfviewer/fragment/JumpToPageFragment.java
+++ b/app/src/main/java/co/copperhead/pdfviewer/fragment/JumpToPageFragment.java
@@ -46,6 +46,7 @@ public class JumpToPageFragment extends DialogFragment {
                 .setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
                     @Override
                     public void onClick(DialogInterface dialogInterface, int i) {
+                        mPicker.clearFocus();
                         ((PdfViewer)getActivity()).positiveButtonRenderPage(mPicker.getValue());
                     }
                 })


### PR DESCRIPTION
The numberpicker doesn't allow selection of a custom page number via keyboard input.
This patch fixes it.